### PR TITLE
Add support for /dev/video 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/ullaakut/rtspatt.svg?style=flat)](https://hub.docker.com/r/ullaakut/rtspatt/)
 [![Latest release](https://img.shields.io/github/release/EtixLabs/RTSPAllTheThings.svg?style=flat)](https://github.com/EtixLabs/RTSPAllTheThings/releases/latest)
 
-### A multipurpose RTSP media server that can simulate RTSP cameras, broadcast RTSP streams and even create test videos or serve video files.
+### A multipurpose RTSP media server that can simulate RTSP cameras, broadcast RTSP streams, webcams and even create test videos or serve video files.
 
 ## Dependencies
 
@@ -71,6 +71,7 @@ All of these environment variables and command line arguments override the defau
   Input used as video source. [default: `pattern:smtpe`]
   - If the argument starts with `rtsp://` it will try to open it as an **RTSP stream**
   - If it starts with `pattern:` if will create a **test video with the given pattern** (_see [this link](https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-base-plugins/html/gst-plugins-base-plugins-videotestsrc.html#GstVideoTestSrcPattern) for more information on this argument_)
+  - If the argument starts with `/dev/video` it will create a stream from the /dev/video device passed into docker at the launch of the instance. You will need to pass in the video device as follows: `--device=/dev/video0:/dev/video0` where `video0` is the video device.
   - Otherwise it will use the argument as a absolute link to **file input**. Remember to use the `-v` option to insert a video into your container if you want to read it. Example: `docker run -e INPUT=/tmp/video.mp4 -v /home/test/documents/myVideo.mp4:/tmp/video -p 8554:8554 ullaakut/rtspatt`. The repository contains a 30 second sample video in the `samples` folder.
 * `ENABLE_TIME_OVERLAY` | `-t`:
   If the environment variable is set to true or the command line flag is used, a time overlay will be added to the stream. This can be useful to debug latency. [default: disabled] - RTSPATT will have to do encoding to add the time (CPU usage)
@@ -89,6 +90,9 @@ All of these environment variables and command line arguments override the defau
 > Broadcast a camera's stream and change its framerate to 12 frames per second:
 
 `docker run --rm -e INPUT="rtsp://root:root@camera_ip:554/live.sdp" -e RTSP_FRAMERATE=12 -p 8554:8554 ullaakut/rtspatt` or `./rtspatt -i rtsp://root:root@camera_ip:554/live.sdp -f 12`
+
+> Broadcast a video stream from a connected device:
+`docker run --rm -e INPUT="/dev/video0" --device=/dev/video0:/dev/video0 -p 8554:8554 rtspatt`
 
 > Serve a video file on a specific address and route:
 

--- a/include/server.h
+++ b/include/server.h
@@ -29,7 +29,7 @@
 #define DEFAULT_HEIGHT "720"
 #define DEFAULT_TIME_ENABLED false
 
-enum InputType { UNDEFINED_INPUT, FILE_INPUT, RTSP_INPUT, VIDEOTESTSRC_INPUT };
+enum InputType { UNDEFINED_INPUT, FILE_INPUT, RTSP_INPUT, VIDEOTESTSRC_INPUT, DEVICE_INPUT };
 
 typedef struct s_config {
   // Server config

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -209,7 +209,7 @@ std::string input_type_to_string(InputType type) {
     return "rtsp";
   case VIDEOTESTSRC_INPUT:
     return "videotestsrc";
-  case DEVICE_INPUT;
+  case DEVICE_INPUT:
     return "v4l2src";
   default:
     break;

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -209,6 +209,8 @@ std::string input_type_to_string(InputType type) {
     return "rtsp";
   case VIDEOTESTSRC_INPUT:
     return "videotestsrc";
+  case DEVICE_INPUT;
+    return "v4l2src"
   default:
     break;
   }

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -210,7 +210,7 @@ std::string input_type_to_string(InputType type) {
   case VIDEOTESTSRC_INPUT:
     return "videotestsrc";
   case DEVICE_INPUT;
-    return "v4l2src"
+    return "v4l2src";
   default:
     break;
   }

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -192,6 +192,8 @@ void parse_input_type(std::shared_ptr<t_config> &config) {
                                                             "pattern:") ==
                                           0) { // Videotestsrc pattern input
     config->input_type = VIDEOTESTSRC_INPUT;
+  } else if (config->input.compare(0, 10, "/dev/video") == 0) { // v4l2src input
+    config->input_type = DEVICE_INPUT;
   } else { // File
     config->input_type = FILE_INPUT;
   }

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -104,6 +104,18 @@ std::string create_file_input(std::shared_ptr<t_config> &config) {
   return launchCmd;
 }
 
+// Device input pipeline
+std::string create_device_input(std::shared_ptr<t_config> &config) {
+  // std::string launchCmd = "";
+
+  // launchCmd += "appsrc name=mysrc";
+  // launchCmd += " ! decodebin";
+
+  // launchCmd += time_overlay(config);
+  // launchCmd += encode(config);
+  // return launchCmd;
+}
+
 /* Create pipeline according to config */
 std::string create_pipeline(std::shared_ptr<t_config> &config) {
   std::string launchCmd = "( ";

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -108,7 +108,7 @@ std::string create_file_input(std::shared_ptr<t_config> &config) {
 std::string create_device_input(std::shared_ptr<t_config> &config) {
   std::string launchCmd = ""; 
 
-  launchCmd += "gst-launch";
+  launchCmd += "gst-launch1.0";
   launchCmd += " v4l2src device=";
   launchCmd += config->input;
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -106,14 +106,15 @@ std::string create_file_input(std::shared_ptr<t_config> &config) {
 
 // Device input pipeline
 std::string create_device_input(std::shared_ptr<t_config> &config) {
-  // std::string launchCmd = "";
+  std::string launchCmd = ""; 
 
-  // launchCmd += "appsrc name=mysrc";
-  // launchCmd += " ! decodebin";
+  launchCmd += "gst-launch";
+  launchCmd += " v4l2src device=";
+  launchCmd += config->input;
 
-  // launchCmd += time_overlay(config);
-  // launchCmd += encode(config);
-  // return launchCmd;
+  launchCmd += time_overlay(config);
+  launchCmd += encode(config);
+  return launchCmd;
 }
 
 /* Create pipeline according to config */

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -108,7 +108,6 @@ std::string create_file_input(std::shared_ptr<t_config> &config) {
 std::string create_device_input(std::shared_ptr<t_config> &config) {
   std::string launchCmd = ""; 
 
-  launchCmd += "gst-launch1.0";
   launchCmd += " v4l2src device=";
   launchCmd += config->input;
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -114,6 +114,8 @@ std::string create_pipeline(std::shared_ptr<t_config> &config) {
     launchCmd += create_videotestsrc_input(config);
   } else if (config->input_type == FILE_INPUT) {
     launchCmd += create_file_input(config);
+  } else if (config->input_type == DEVICE_INPUT) {
+    launchCmd += create_device_input(config);
   }
 
   launchCmd += " ! rtph264pay name=pay0 pt=96 ";


### PR DESCRIPTION
Tested this locally with a MacBook Facetime cam, passed into an ubuntu instance as /dev/video0 successfully.
Never done cpp, so please feel free to comment/correct my work.