### PR TITLE
Add digest auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER brendan.leglaunec@etixgroup.com
+MAINTAINER brendan.le-glaunec@epitech.eu
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libgstrtspserver-1.0-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:17.10
 
 MAINTAINER brendan.le-glaunec@epitech.eu
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/ullaakut/rtspatt.svg?style=flat)](https://hub.docker.com/r/ullaakut/rtspatt/)
 [![Latest release](https://img.shields.io/github/release/EtixLabs/RTSPAllTheThings.svg?style=flat)](https://github.com/EtixLabs/RTSPAllTheThings/releases/latest)
 
-### A multipurpose RTSP media server that can simulate RTSP cameras, broadcast RTSP streams, webcams and even create test videos or serve video files.
+**A multipurpose RTSP media server that can simulate RTSP cameras, broadcast RTSP streams, webcams and even create test videos or serve video files.**
 
 ## Dependencies
 
@@ -33,6 +33,7 @@ docker run --rm \
        [-e RTSP_FRAMERATE=your_framerate] \
        [-e INPUT=your_input] \
        [-e ENABLE_TIME_OVERLAY=true|false] \
+       [-e RTSP_AUTHENTICATION_METHOD=digest|basic] \
        [-e GST_DEBUG=your_debug_level] \
        ullaakut/rtspatt
 ```
@@ -47,6 +48,7 @@ docker run --rm \
       [-s rtsp_resolution] \
       [-f rtsp_framerate] \
       [-t] \
+      [-d] \
       [-i input]
 ```
 
@@ -64,9 +66,9 @@ All of these environment variables and command line arguments override the defau
 * `RTSP_PASSWORD` | `-p`:
   If you want to enable security on your stream, using this option will allow you to specify the password required to access your stream [default: none]
 * `RTSP_RESOLUTION` | `-s`:
-  The resolution at which you want to stream [default: `1280x720`] - RTSPATT will have to do encoding to resize the stream (CPU usage)
+  The resolution at which you want to stream [default: `1280x720`] - RTSPATT will have to do encoding to resize the stream (Increased CPU usage)
 * `RTSP_FRAMERATE` | `-f`:
-  The desired output framerate for your stream [default: `25`] - RTSPATT will have to do encoding to change the framerate (CPU usage)
+  The desired output framerate for your stream [default: `25`] - RTSPATT will have to do encoding to change the framerate (Increased CPU usage)
 * `INPUT` | `-i`:
   Input used as video source. [default: `pattern:smtpe`]
   - If the argument starts with `rtsp://` it will try to open it as an **RTSP stream**
@@ -74,7 +76,9 @@ All of these environment variables and command line arguments override the defau
   - If the argument starts with `/dev/video` it will create a stream from the /dev/video device passed into docker at the launch of the instance. You will need to pass in the video device as follows: `--device=/dev/video0:/dev/video0` where `video0` is the video device.
   - Otherwise it will use the argument as a absolute link to **file input**. Remember to use the `-v` option to insert a video into your container if you want to read it. Example: `docker run -e INPUT=/tmp/video.mp4 -v /home/test/documents/myVideo.mp4:/tmp/video -p 8554:8554 ullaakut/rtspatt`. The repository contains a 30 second sample video in the `samples` folder.
 * `ENABLE_TIME_OVERLAY` | `-t`:
-  If the environment variable is set to true or the command line flag is used, a time overlay will be added to the stream. This can be useful to debug latency. [default: disabled] - RTSPATT will have to do encoding to add the time (CPU usage)
+  If the environment variable is set to true or the command line flag is used, a time overlay will be added to the stream. This can be useful to debug latency. [default: disabled] - RTSPATT will have to do encoding to add the time (Increased CPU usage)
+* `RTSP_AUTHENTICATION_METHOD` | `-d`:
+  If RTSP_AUTHENTICATION_METHOD is set to `digest` or the command line flag is used, the authentication will be done using digest instead of basic auth. [default: basic]
 * `GST_DEBUG`:
   The desired debug level for GStreamer [default: none] (_see [this link](https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/gst-running.html) for more information on this variable_)
 
@@ -82,6 +86,13 @@ All of these environment variables and command line arguments override the defau
 
 <p align="center"><img src="https://preview.ibb.co/emxVna/Example_Screen_Shot.png" alt="Ball"></p>
 
+> Serve video using basic auth on `rtsp:admin:test@//0.0.0.0:8554/live.sdp`
+
+`docker run --rm -e RTSP_USERNAME=admin  -e RTSP_PASSWORD=test -p 8554:8554 rtspatt`
+
+> Serve video using digest auth on `rtsp:admin:test@//0.0.0.0:8554/live.sdp`
+
+`docker run --rm -e RTSP_AUTHENTICATION_METHOD=digest -e RTSP_USERNAME=admin  -e RTSP_PASSWORD=test -p 8554:8554 rtspatt`
 
 > Launch an RTSP stream on `rtsp://0.0.0.0:8554/live.sdp` with a snow pattern and a resolution of 960x600 pixels:
 
@@ -92,6 +103,7 @@ All of these environment variables and command line arguments override the defau
 `docker run --rm -e INPUT="rtsp://root:root@camera_ip:554/live.sdp" -e RTSP_FRAMERATE=12 -p 8554:8554 ullaakut/rtspatt` or `./rtspatt -i rtsp://root:root@camera_ip:554/live.sdp -f 12`
 
 > Broadcast a video stream from a connected device:
+
 `docker run --rm -e INPUT="/dev/video0" --device=/dev/video0:/dev/video0 -p 8554:8554 rtspatt`
 
 > Serve a video file on a specific address and route:
@@ -112,6 +124,7 @@ With default options, stream will be available at `rtsp://0.0.0.0:8554/live.sdp`
 You can use [override options](#override-options).
 
 ## Patterns
+
 Here is the list of patterns you can use
 
 * `pattern:smpte`               - The standard SMTPE test pattern, it's the default value if you don't specify any input

--- a/build_image/Dockerfile-build
+++ b/build_image/Dockerfile-build
@@ -1,6 +1,4 @@
-FROM ubuntu:16.04
-
-MAINTAINER brendan.le-glaunec@epitech.eu
+FROM ubuntu:17.10
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \

--- a/build_image/Dockerfile-build
+++ b/build_image/Dockerfile-build
@@ -1,4 +1,6 @@
-FROM ubuntu:16.10
+FROM ubuntu:16.04
+
+MAINTAINER brendan.le-glaunec@epitech.eu
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \

--- a/include/server.h
+++ b/include/server.h
@@ -28,6 +28,7 @@
 #define DEFAULT_WIDTH "1280"
 #define DEFAULT_HEIGHT "720"
 #define DEFAULT_TIME_ENABLED false
+#define DEFAULT_DIGEST_ENABLED false
 
 enum InputType { UNDEFINED_INPUT, FILE_INPUT, RTSP_INPUT, VIDEOTESTSRC_INPUT, DEVICE_INPUT };
 
@@ -49,6 +50,7 @@ typedef struct s_config {
 
   // Options
   bool time;
+  bool digest;
 } t_config;
 
 typedef struct s_server {
@@ -59,6 +61,7 @@ typedef struct s_server {
   GstRTSPAuth *auth;
   GstRTSPToken *token;
   gchar *basic;
+
   std::shared_ptr<t_config> config;
 } t_server;
 

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -78,12 +78,23 @@ void parse_env(std::shared_ptr<t_config> &config) {
     config->input = input;
   }
 
+  // Time
   config->time = DEFAULT_TIME_ENABLED;
   if (const char *time = std::getenv("ENABLE_TIME_OVERLAY")) {
     if (strcmp(time, "false") == 0) {
       config->time = false;
     } else {
       config->time = true;
+    }
+  }
+
+  // Digest auth (if anything other than digest, basic will be used)
+  config->digest = DEFAULT_DIGEST_ENABLED;
+  if (const char *auth = std::getenv("RTSP_AUTHENTICATION_METHOD")) {
+    if (strcmp(auth, "digest") == 0) {
+      config->digest = true;
+    } else {
+      config->digest = false;
     }
   }
 }
@@ -224,7 +235,15 @@ void dump_config(std::shared_ptr<t_config> &config) {
             << "Route:\t\t" << config->route << std::endl
             << "Username:\t" << config->username << std::endl
             << "Password:\t" << config->password << std::endl
-            << std::endl;
+            << "Auth method:\t";
+
+            if (config->digest) {
+              std::cout << "Digest";
+            } else {
+              std::cout << "Basic";
+            }
+
+           std::cout << std::endl;
 
   // Input
   std::cout << "Input:\t\t";

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -170,11 +170,14 @@ bool parse_args(std::shared_ptr<t_config> &config, int argc, char **argv) {
     case 't': // Time Overlay
       config->time = true;
       break;
+    case 'd': // Use digest instead of basic auth
+      config->digest = true;
+      break;
     case 'h': // help
       fprintf(stdout,
               "Usage: %s [-l address] [-b port] [-r route] [-i "
               "input] [-u username] [-p password] [-f framerate] [-s "
-              "'width'x'height'] [-t] [-h]\n",
+              "'width'x'height'] [-d] [-t] [-h]\n",
               argv[0]);
       return true;
     case '?':

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -241,9 +241,9 @@ void dump_config(std::shared_ptr<t_config> &config) {
             << "Auth method:\t";
 
             if (config->digest) {
-              std::cout << "Digest";
+              std::cout << "digest";
             } else {
-              std::cout << "Basic";
+              std::cout << "basic";
             }
 
            std::cout << std::endl;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -63,10 +63,16 @@ void server_init(t_server *serv) {
     serv->token =
         gst_rtsp_token_new(GST_RTSP_TOKEN_MEDIA_FACTORY_ROLE, G_TYPE_STRING,
                            serv->config->username.c_str(), NULL);
+
+  if (serv->config->digest) {
+    gst_rtsp_auth_set_supported_methods(serv->auth, GST_RTSP_AUTH_DIGEST);
+    gst_rtsp_auth_set_default_token(serv->auth, serv->token);
+  } else {
     serv->basic = gst_rtsp_auth_make_basic(serv->config->username.c_str(),
                                            serv->config->password.c_str());
     gst_rtsp_auth_add_basic(serv->auth, serv->basic, serv->token);
     g_free(serv->basic);
+  }
     gst_rtsp_token_unref(serv->token);
 
     /* set as the server authentication manager */

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -66,6 +66,7 @@ void server_init(t_server *serv) {
 
   if (serv->config->digest) {
     gst_rtsp_auth_set_supported_methods(serv->auth, GST_RTSP_AUTH_DIGEST);
+    gst_rtsp_auth_add_digest(serv->auth, serv->config->username.c_str(), serv->config->password.c_str(), serv->token);
     gst_rtsp_auth_set_default_token(serv->auth, serv->token);
   } else {
     serv->basic = gst_rtsp_auth_make_basic(serv->config->username.c_str(),

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -67,7 +67,6 @@ void server_init(t_server *serv) {
   if (serv->config->digest) {
     gst_rtsp_auth_set_supported_methods(serv->auth, GST_RTSP_AUTH_DIGEST);
     gst_rtsp_auth_add_digest(serv->auth, serv->config->username.c_str(), serv->config->password.c_str(), serv->token);
-    gst_rtsp_auth_set_default_token(serv->auth, serv->token);
   } else {
     serv->basic = gst_rtsp_auth_make_basic(serv->config->username.c_str(),
                                            serv->config->password.c_str());


### PR DESCRIPTION
- Update of the Ubuntu versions used to build to get the latest gst-rtsp-server builds with digest & to fix builds that were broken since 16.10 became deprecated
- Add digest authentication
- Update README with basic & digest auth examples